### PR TITLE
Default branch to current repo, allow project via env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,11 @@ cci -t your-token    \
     -l a-limit         # default of 5
 ```
 
+## Ideas
+
+- [ ] (Khiem Lam) Use relative time for builds (N minutes ago...) rather than
+      absolute.
+
 ## License
 
 Copyright © 2018 Daniel Gregoire

--- a/deps.edn
+++ b/deps.edn
@@ -3,6 +3,7 @@
         cheshire {:mvn/version "5.8.0"}
         clansi {:mvn/version "1.0.0"}
         clj-jgit {:mvn/version "0.8.10"}
+        clojure.java-time {:mvn/version "0.3.2"}
         ;; Uses advanced clojure.pprint facilities which are not compatible with
         ;; GraalVM at this time.
         ;; org.clojure/tools.cli {:mvn/version "0.3.7"}

--- a/deps.edn
+++ b/deps.edn
@@ -2,6 +2,7 @@
  :deps {org.clojure/clojure {:mvn/version "RELEASE"}
         cheshire {:mvn/version "5.8.0"}
         clansi {:mvn/version "1.0.0"}
+        clj-jgit {:mvn/version "0.8.10"}
         ;; Uses advanced clojure.pprint facilities which are not compatible with
         ;; GraalVM at this time.
         ;; org.clojure/tools.cli {:mvn/version "0.3.7"}

--- a/script/compile
+++ b/script/compile
@@ -25,7 +25,7 @@ fi
 mkdir -p target/custom/bin
 
 cd $CLASSES_FOLDER
-$GRAAL_HOME/bin/native-image com.semperos.cci
+$GRAAL_HOME/bin/native-image -H:+ReportUnsupportedElementsAtRuntime com.semperos.cci
 cd ../../..
 
 cp $CLASSES_FOLDER/com.semperos.cci $TARGET_FILE


### PR DESCRIPTION
* Leverage `CIRCLE_PROJECT` or `CIRCLECI_PROJECT` if defined as an environment variable, can be used in place of explicit `-p/--project` CLI argument.
* Use the current directory's Git repo's branch if present.